### PR TITLE
Add an eslint linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,18 @@ six>=1.10.0  # noqa: allow any recent version of six
 
 [req-txt]: https://pip.readthedocs.org/en/latest/user_guide/#requirements-files
 
+### Eslint linter
+
+Lints JavaScript and JSX files.
+
+```json
+{
+    "type": "eslint",
+    "include": "(\\.js$)",
+    "eslint.bin": "./node_modules/.bin/eslint",
+}
+```
+
 ## Installation
 
 In short, you'll need to add this repository to your local machine and tell

--- a/README.md
+++ b/README.md
@@ -63,6 +63,20 @@ code against a coding standard.
 }
 ```
 
+### ESLint Linter
+
+Lints JavaScript and JSX files using [ESLint](https://eslint.org/).
+
+```json
+{
+    "type": "eslint",
+    "include": "(\\.js$)",
+    "bin": "./node_modules/.bin/eslint",
+    "eslint.config": "~/my-eslint.json",
+    "eslint.env": "browser,node"
+}
+```
+
 ### Go Vet Linter
 
 Uses the [Go vet command](https://golang.org/cmd/vet/) to lint for suspicious
@@ -107,18 +121,6 @@ six>=1.10.0  # noqa: allow any recent version of six
 ```
 
 [req-txt]: https://pip.readthedocs.org/en/latest/user_guide/#requirements-files
-
-### Eslint linter
-
-Lints JavaScript and JSX files.
-
-```json
-{
-    "type": "eslint",
-    "include": "(\\.js$)",
-    "eslint.bin": "./node_modules/.bin/eslint",
-}
-```
 
 ## Installation
 

--- a/__phutil_library_map__.php
+++ b/__phutil_library_map__.php
@@ -11,7 +11,7 @@ phutil_register_library_map(array(
   'class' => array(
     'ApacheThriftGeneratedLinter' => 'src/ApacheThriftGeneratedLinter.php',
     'ApacheThriftLinter' => 'src/ApacheThriftLinter.php',
-    'ArcanistEslintLinter' => 'src/ArcanistEslintLinter.php',
+    'ESLintLinter' => 'src/ESLintLinter.php',
     'CheckstyleLinter' => 'src/CheckstyleLinter.php',
     'GoVetLinter' => 'src/GoVetLinter.php',
     'PythonImportsLinter' => 'src/PythonImportsLinter.php',
@@ -21,7 +21,7 @@ phutil_register_library_map(array(
   'xmap' => array(
     'ApacheThriftGeneratedLinter' => 'ArcanistLinter',
     'ApacheThriftLinter' => 'ArcanistExternalLinter',
-    'ArcanistEslintLinter' => 'ArcanistExternalLinter',
+    'ESLintLinter' => 'ArcanistExternalLinter',
     'CheckstyleLinter' => 'ArcanistExternalLinter',
     'GoVetLinter' => 'ArcanistExternalLinter',
     'PythonImportsLinter' => 'ArcanistLinter',

--- a/__phutil_library_map__.php
+++ b/__phutil_library_map__.php
@@ -11,6 +11,7 @@ phutil_register_library_map(array(
   'class' => array(
     'ApacheThriftGeneratedLinter' => 'src/ApacheThriftGeneratedLinter.php',
     'ApacheThriftLinter' => 'src/ApacheThriftLinter.php',
+    'ArcanistEslintLinter' => 'src/ArcanistEslintLinter.php',
     'CheckstyleLinter' => 'src/CheckstyleLinter.php',
     'GoVetLinter' => 'src/GoVetLinter.php',
     'PythonImportsLinter' => 'src/PythonImportsLinter.php',
@@ -20,6 +21,7 @@ phutil_register_library_map(array(
   'xmap' => array(
     'ApacheThriftGeneratedLinter' => 'ArcanistLinter',
     'ApacheThriftLinter' => 'ArcanistExternalLinter',
+    'ArcanistEslintLinter' => 'ArcanistExternalLinter',
     'CheckstyleLinter' => 'ArcanistExternalLinter',
     'GoVetLinter' => 'ArcanistExternalLinter',
     'PythonImportsLinter' => 'ArcanistLinter',

--- a/src/ArcanistEslintLinter.php
+++ b/src/ArcanistEslintLinter.php
@@ -1,0 +1,108 @@
+<?php
+
+final class ArcanistEslintLinter extends ArcanistExternalLinter {
+  const ESLINT_WARNING = '1';
+  const ESLINT_ERROR = '2';
+
+  public function getInfoName() {
+    return 'Eslint';
+  }
+
+  public function getInfoURI() {
+    return 'http://eslint.org/';
+  }
+
+  public function getInfoDescription() {
+    return pht('The pluggable linting utility for JavaScript and JSX');
+  }
+
+  public function getLinterName() {
+    return 'ESLINT';
+  }
+
+  public function getLinterConfigurationName() {
+    return 'eslint';
+  }
+
+  public function getDefaultBinary() {
+    return 'eslint';
+  }
+
+  protected function getMandatoryFlags() {
+    return array(
+      '--format=json',
+      '--no-color',
+    );
+  }
+
+  public function getVersion() {
+    list($err, $stdout, $stderr) = exec_manual('%C -v', $this->getExecutableCommand());
+
+    return $err
+      ? false
+      : $stdout;
+  }
+
+  public function getLinterConfigurationOptions() {
+    $options = array(
+      'eslint.bin' => array(
+        'type' => 'optional string',
+        'help' => pht('Location of eslint executable. Default: (eslint)'),
+      ),
+    );
+    return $options + parent::getLinterConfigurationOptions();
+  }
+
+  public function setLinterConfigurationValue($key, $value) {
+    switch ($key) {
+      case 'eslint.bin':
+        $this->setBinary($value);
+        return;
+    }
+    return parent::setLinterConfigurationValue($key, $value);
+  }
+
+  public function getInstallInstructions() {
+    return pht(
+      'run `%s` to install eslint globally, or `%s` to add it to your project.',
+      'npm install --global eslint',
+      'npm install --save-dev eslint'
+    );
+  }
+
+  protected function canCustomizeLintSeverities() {
+    return false;
+  }
+
+  protected function parseLinterOutput($path, $err, $stdout, $stderr) {
+    $json = json_decode($stdout, true);
+    $messages = array();
+
+    foreach ($json as $file) {
+      foreach ($file['messages'] as $offense) {
+        $message = new ArcanistLintMessage();
+        $message->setPath($file['filePath']);
+        $message->setSeverity($this->mapSeverity($offense['severity']));
+        $message->setName($offense['ruleId']);
+        $message->setDescription($offense['message']);
+        $message->setLine($offense['line']);
+        $message->setChar($offense['column']);
+        $message->setCode($offense['source']);
+        $messages[] = $message;
+      }
+    }
+
+    return $messages;
+  }
+
+  private function mapSeverity($eslintSeverity) {
+    switch($eslintSeverity) {
+      case '0':
+      case '1':
+        return ArcanistLintSeverity::SEVERITY_WARNING;
+      case '2':
+      default:
+        return ArcanistLintSeverity::SEVERITY_ERROR;
+    }
+  }
+}

--- a/src/ESLintLinter.php
+++ b/src/ESLintLinter.php
@@ -1,5 +1,23 @@
 <?php
+/**
+ * Copyright 2016 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
+/**
+ * Lints JavaScript and JSX files using ESLint
+ */
 final class ESLintLinter extends ArcanistExternalLinter {
   const ESLINT_WARNING = '1';
   const ESLINT_ERROR = '2';


### PR DESCRIPTION
Adds a linter to check for errors in JavaScript and JSX files.

The binary to use is set as a configuration option, so it can be project specific. The default is to try and use `eslint` that's on your $PATH.