### PR TITLE
Some small fixes

### DIFF
--- a/src/.eslint-zero.sh
+++ b/src/.eslint-zero.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+./node_modules/eslint/bin/eslint.js "$@"
+exit 0

--- a/src/.prettier-zero.sh
+++ b/src/.prettier-zero.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+./node_modules/.bin/prettier "$@"
+exit 0

--- a/src/.prettier-zero.sh
+++ b/src/.prettier-zero.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-./node_modules/.bin/prettier "$@"
-exit 0

--- a/src/ESLintLinter.php
+++ b/src/ESLintLinter.php
@@ -125,7 +125,9 @@ final class ESLintLinter extends ArcanistExternalLinter {
         $message->setDescription($offense['message']);
         $message->setLine($offense['line']);
         $message->setChar($offense['column']);
-        $message->setCode($offense['source']);
+        if(array_key_exists('source', $offense)){
+            $message->setCode($offense['source']);
+        }
         $messages[] = $message;
       }
     }

--- a/src/ESLintLinter.php
+++ b/src/ESLintLinter.php
@@ -45,7 +45,7 @@ final class ESLintLinter extends ArcanistExternalLinter {
   }
 
   public function getDefaultBinary() {
-    return 'eslint';
+    return __DIR__ . "/.eslint-zero.sh";
   }
 
   public function getVersion() {

--- a/src/PrettierLinter.php
+++ b/src/PrettierLinter.php
@@ -42,7 +42,23 @@ final class PrettierLinter extends ArcanistExternalLinter {
   }
 
   public function getDefaultBinary() {
-      return __DIR__ . "/.prettier-zero.sh";
+    list($err, $stdout, $stderr) = exec_manual('yarn -s --cwd %s bin', $this->getProjectRoot() . '/' . $this->cwd);
+    if (empty($stdout)) {
+      // Copied from arcanist/master/src/lint/linter/ArcanistExternalLinter.php
+      throw new ArcanistMissingLinterException(
+        sprintf(
+          "%s\n%s",
+          pht(
+            'Unable to locate script "%s" to run linter %s. You may need '.
+            'to install the script, or adjust your linter configuration.',
+            'yarn@1',
+            get_class($this)),
+            pht(
+              'TO INSTALL: %s',
+              $this->getInstallInstructions())));
+    }
+    $binaryPath = strtok($stdout, "\n");
+    return $binaryPath . "/prettier";
   }
 
     

--- a/src/PrettierLinter.php
+++ b/src/PrettierLinter.php
@@ -47,6 +47,7 @@ final class PrettierLinter extends ArcanistExternalLinter {
     return $binaryPath;
   }
 
+    
   public function getVersion() {
     list($err, $stdout, $stderr) = exec_manual('%C -v', $this->getExecutableCommand());
     return $stdout;
@@ -84,6 +85,10 @@ final class PrettierLinter extends ArcanistExternalLinter {
       return false;
     }
 
+    if($this->getData($path)==$stdout){
+        return array();
+    }
+    
     $message = new ArcanistLintMessage();
     $message->setPath($path);
     $message->setSeverity(ArcanistLintSeverity::SEVERITY_AUTOFIX);
@@ -91,7 +96,7 @@ final class PrettierLinter extends ArcanistExternalLinter {
     $message->setLine(1);
     $message->setCode($this->getLinterName());
     $message->setChar(1);
-    $message->setDescription('Your file has not been prettier-ified');
+    $message->setDescription('This file has not been prettier-ified');
     $message->setOriginalText($this->getData($path));
     $message->setReplacementText($stdout);
     $messages[] = $message;

--- a/src/PrettierLinter.php
+++ b/src/PrettierLinter.php
@@ -83,7 +83,7 @@ final class PrettierLinter extends ArcanistExternalLinter {
       return false;
     }
 
-    if($this->getData($path)==$stdout){
+    if ($this->getData($path) == $stdout || $stdout == "") {
         return array();
     }
     

--- a/src/PrettierLinter.php
+++ b/src/PrettierLinter.php
@@ -42,9 +42,7 @@ final class PrettierLinter extends ArcanistExternalLinter {
   }
 
   public function getDefaultBinary() {
-    list($err, $stdout, $stderr) = exec_manual('yarn -s --cwd %s which prettier', $this->getProjectRoot() . '/' . $this->cwd);
-    $binaryPath = strtok($stdout, "\n");
-    return $binaryPath;
+      return __DIR__ . "/.prettier-zero.sh";
   }
 
     


### PR DESCRIPTION
1. Prettier linter now doesn't show a warning for files that don't require any formatting changes (are already formatted)
2. ESLintLinter and PrettierLinter now don't throw an error because of return status code `1`
3. Fix ESLinter failing because of missing `source` parameter in some of messages in eslint output