### PR TITLE
Update Checkstyle regex to correctly parse line & char values from output

### DIFF
--- a/src/CheckstyleLinter.php
+++ b/src/CheckstyleLinter.php
@@ -97,7 +97,7 @@ final class CheckstyleLinter extends ArcanistExternalLinter {
     // [ERROR] /path/to/file.java:31: Message text [Indentation]
     // [WARN] /path/to/file.java:31:10: Message text [Indentation]
     $regex = '/^\[(?P<severity>[A-Z]+)\] '.
-      '(?P<path>.*):(?P<line>\d+):(?:(?P<char>\d+):)? '.
+      '(?P<path>.*?):(?P<line>\d+):(?:(?P<char>\d+):)? '.
       '(?P<message>.*) \[(?P<type>.*)\]$/';
 
     $messages = array();


### PR DESCRIPTION
When trying out the Checkstyle linter, I noticed that we sometimes weren't parsing out the correct line and character values. This then would cause the `ArcanistLintMessage` to point to the wrong spot in the code.

For example, using the following example output:

`[WARN] /some/path/to/file.java:49:8: Unused import - com.some.package.Class. [UnusedImports]`

The existing regex would incorrectly believe `path` was `/some/path/to/file.java:49` and the line number was `8`. With the proposed pull request of making the regex lazy for the `path` grouping, we will then correctly have `path` be `/some/path/to/file.java`, line number be `49`, and character be `8`.

The canonical output of `[WARN] /some/path.java:123: Some message [etc]` is still parsed correctly.