### PR TITLE
Set a default name for rules with null names

### DIFF
--- a/src/ESLintLinter.php
+++ b/src/ESLintLinter.php
@@ -163,7 +163,7 @@ final class ESLintLinter extends ArcanistExternalLinter {
         $message = new ArcanistLintMessage();
         $message->setPath($file['filePath']);
         $message->setSeverity($this->mapSeverity($offense['severity']));
-        $message->setName($offense['ruleId']);
+        $message->setName($offense['ruleId'] || 'unknown');
         $message->setDescription($offense['message']);
         $message->setLine($offense['line']);
         $message->setChar($offense['column']);


### PR DESCRIPTION
Parsing errors come out with null names, which crashes arc. Give null names a name.