### PR TITLE
Skip file ignored warning

### DIFF
--- a/src/ESLintLinter.php
+++ b/src/ESLintLinter.php
@@ -160,6 +160,13 @@ final class ESLintLinter extends ArcanistExternalLinter {
 
     foreach ($json as $file) {
       foreach ($file['messages'] as $offense) {
+        // Skip file ignored warning: if a file is ignored by .eslintingore
+        // but linted explicitly (by arcanist), a warning will be reported,
+        // containing only: `{fatal:false,serverity:1,message:...}`.
+        if (strpos($offense['message'], "File ignored because") === 0) {
+          continue;
+        }
+
         $message = new ArcanistLintMessage();
         $message->setPath($file['filePath']);
         $message->setSeverity($this->mapSeverity($offense['severity']));


### PR DESCRIPTION
First of all, thanks for publishing your linters!

I've been into an issue with the `eslint` linter: My `.arclint` enables the linter for `"include": ["(\\.(j|t)sx?$)"],` while excludes are defined in `.eslintignore` (so that other tools also respect them).

Some version of ESLint (IIRC last year) started emitting a warning so that if one invokes `eslint some-ignored-file.js`, it communicates to the user that it ignored it.

The warning doesn't have most fields set, so PHP emits a bunch of warnings when building `ArcanistLintMessage`. This change makes the linter just ignore that warning.