### PR TITLE
Ignore "File ignored by default" messages in eslint

### DIFF
--- a/src/ESLintLinter.php
+++ b/src/ESLintLinter.php
@@ -163,7 +163,7 @@ final class ESLintLinter extends ArcanistExternalLinter {
         // Skip file ignored warning: if a file is ignored by .eslintingore
         // but linted explicitly (by arcanist), a warning will be reported,
         // containing only: `{fatal:false,serverity:1,message:...}`.
-        if (strpos($offense['message'], "File ignored because") === 0) {
+        if (strpos($offense['message'], "File ignored ") === 0) {
           continue;
         }
 


### PR DESCRIPTION
I found eslint sometimes has a message "File ignored by default", which causes errors.

I think it would be more robust if you just check for the presence of the `ruleId` field which seems to be missing for the ignored files, but I don't know PHP so I'll leave that to you.