### PR TITLE
Black linter message

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ to normalize the format of Python code.
 {
     "type": "black",
     "include": "(\\.py$)",
-    "black.linelen": 132
+    "flags": ["--check", "-S", "--line-length=132"]
 }
 ```
 

--- a/src/BlackLinter.php
+++ b/src/BlackLinter.php
@@ -81,7 +81,10 @@ final class BlackLinter extends ArcanistExternalLinter {
   }
 
   protected function getMandatoryFlags() {
-    $flags = array('--quiet');
+    $flags = array('--check');
+    if (!$this->normalizestring) {
+        array_push($flags, '--skip-string-normalization');
+    }
     if ($this->linelen != null) {
         array_push($flags, '--line-length', $this->linelen);
     }

--- a/src/BlackLinter.php
+++ b/src/BlackLinter.php
@@ -97,7 +97,6 @@ final class BlackLinter extends ArcanistExternalLinter {
 
   protected function parseLinterOutput($path, $err, $stdout, $stderr) {
     $lines = phutil_split_lines($stderr, false);
-    $messages = array();
     $message = new ArcanistLintMessage();
     $message->setPath($path);
     $message->setName($this->getLinterName());

--- a/src/BlackLinter.php
+++ b/src/BlackLinter.php
@@ -62,7 +62,7 @@ final class BlackLinter extends ArcanistExternalLinter {
       ),
       'black.normalizestring' => array(
         'type' => 'optional bool',
-        'help' => pht('Whether '),
+        'help' => pht('Whether to normalize strings'),
       ),
     );
     return $options + parent::getLinterConfigurationOptions();

--- a/src/BlackLinter.php
+++ b/src/BlackLinter.php
@@ -57,17 +57,18 @@ final class BlackLinter extends ArcanistExternalLinter {
   }
 
   protected function parseLinterOutput($path, $err, $stdout, $stderr) {
+    if ($err == 123 or $stderr) {
+      return false;
+    }
     $flags = $this->getCommandFlags();
-
     // Remove --check flag since instructions to user should be to fix lint errors 
     unset($flags[array_search('--check', $flags)]);
 
-    $lines = phutil_split_lines($stderr, false);
     $message = new ArcanistLintMessage();
     $message->setPath($path);
     $message->setName($this->getLinterName());
-    $message->setDescription("Please run `black ".join(" ", $flags)." ".$path."`\n");
-    $message->setSeverity($this->getLintMessageSeverity('1'));
+    $message->setDescription("Please run `".$this->getLinterConfigurationName()." ".join(" ", $flags)." ".$path."`\n");
+    $message->setSeverity(ArcanistLintSeverity::SEVERITY_ADVICE);
     $messages[] = $message;
     return $messages;
   }

--- a/src/BlackLinter.php
+++ b/src/BlackLinter.php
@@ -67,7 +67,7 @@ final class BlackLinter extends ArcanistExternalLinter {
     $message = new ArcanistLintMessage();
     $message->setPath($path);
     $message->setName($this->getLinterName());
-    $message->setDescription("Please run `".$this->getLinterConfigurationName()." ".join(" ", $flags)." ".$path."`\n");
+    $message->setDescription("Please run `black ".join(" ", $flags)." ".$path."`\n");
     $message->setSeverity(ArcanistLintSeverity::SEVERITY_ADVICE);
     $messages[] = $message;
     return $messages;


### PR DESCRIPTION
• Change `--quiet` to `--check`, this will result in messages that the linter failed rather than quietly making changes, which may compete with other linters like isort
• Add `--skip-string-normalization` option
• More verbose error message for when `--check` fails:
```
   Error  () BLACK
    Please run `black -S <FILEPATH>`
```
for when black.stringnormalizaton = false

and
```
   Error  () BLACK
    Please run `black <FILEPATH>`
```
for when black.stringnormalizaton = true