### PR TITLE
ESLintLinter: Pass name as code

### DIFF
--- a/src/ESLintLinter.php
+++ b/src/ESLintLinter.php
@@ -174,8 +174,7 @@ final class ESLintLinter extends ArcanistExternalLinter {
         $message->setDescription($offense['message']);
         $message->setLine($offense['line']);
         $message->setChar($offense['column']);
-        $source = array_key_exists('source', $offense) ? $offense['source'] : $file['filePath'];
-        $message->setCode($source);
+        $message->setCode($this->getLinterName());
         $messages[] = $message;
       }
     }


### PR DESCRIPTION
The code isn't supposed to be the violating source code, but some "identifier" for the violation.  Some [examples](https://github.com/phacility/arcanist/blob/222800a86ed002c564e2760d6c5d9e93810b5b96/src/lint/linter/ArcanistTextLinter.php#L8-L16) are:

```
final class ArcanistTextLinter extends ArcanistLinter {
  const LINT_DOS_NEWLINE          = 1;
  const LINT_TAB_LITERAL          = 2;
  const LINT_LINE_WRAP            = 3;
  const LINT_EOF_NEWLINE          = 4;
  const LINT_BAD_CHARSET          = 5;
  const LINT_TRAILING_WHITESPACE  = 6;
  const LINT_BOF_WHITESPACE       = 8;
  const LINT_EOF_WHITESPACE       = 9;
  const LINT_EMPTY_FILE           = 10;
```

A common pattern seems to be to just pass `$this->getLinterName()` there's just no real code. Also done in the `PrettierLinter` in this repo.