### PR TITLE
Lower the priority of the isort linter

### DIFF
--- a/src/PythonIsortLinter.php
+++ b/src/PythonIsortLinter.php
@@ -44,6 +44,10 @@ final class PythonIsortLinter extends ArcanistExternalLinter {
     return 'isort';
   }
 
+  public function getLinterPriority() {
+    return 0.4;
+  }
+
   public function getDefaultBinary() {
     return 'isort';
   }


### PR DESCRIPTION
This means it will run earlier in the linting sequence, which is helpful
because it deals with style and emits autofix patch output.