### PR TITLE
Escape hyphens in regex character classes

### DIFF
--- a/src/PythonRequirementsLinter.php
+++ b/src/PythonRequirementsLinter.php
@@ -62,9 +62,9 @@ final class PythonRequirementsLinter extends ArcanistLinter {
 
   private function parseRequirement($line) {
     # PEP 508 (https://www.python.org/dev/peps/pep-0508/)
-    $regex = "/^(?P<name>[[:alnum:]][[:alnum:]-_.]*(?:\[[[:alnum:]]+\])?)".
+    $regex = "/^(?P<name>[[:alnum:]][[:alnum:]\-_.]*(?:\[[[:alnum:]]+\])?)".
              "(?:\s*(?P<cmp>(~=|==|!=|<=|>=|<|>|===))\s*".
-             "(?P<version>[[:alnum:]-_.*+!]+))?".
+             "(?P<version>[[:alnum:]\-_.*+!]+))?".
              "(?:\s*;\s*(?P<environment>[^#]*))?/";
 
     $matches = array();


### PR DESCRIPTION
This was an oversight that now results in PCRE compilation errors
("invalid range in character class").