### PR TITLE
Fix ruleID being set to 'true' 

### DIFF
--- a/src/ESLintLinter.php
+++ b/src/ESLintLinter.php
@@ -166,11 +166,16 @@ final class ESLintLinter extends ArcanistExternalLinter {
         if (strpos($offense['message'], "File ignored ") === 0) {
           continue;
         }
-
+        
+        $ruleid = $offense['ruleId'];
+        if(!$ruleid){
+            $ruleid = 'unknown';
+        }
+        
         $message = new ArcanistLintMessage();
         $message->setPath($file['filePath']);
         $message->setSeverity($this->mapSeverity($offense['severity']));
-        $message->setName($offense['ruleId'] || 'unknown');
+        $message->setName($ruleid);
         $message->setDescription($offense['message']);
         $message->setLine($offense['line']);
         $message->setChar($offense['column']);

--- a/src/ESLintLinter.php
+++ b/src/ESLintLinter.php
@@ -167,15 +167,10 @@ final class ESLintLinter extends ArcanistExternalLinter {
           continue;
         }
         
-        $ruleid = $offense['ruleId'];
-        if(!$ruleid){
-            $ruleid = 'unknown';
-        }
-        
         $message = new ArcanistLintMessage();
         $message->setPath($file['filePath']);
         $message->setSeverity($this->mapSeverity($offense['severity']));
-        $message->setName($ruleid);
+        $message->setName(idx($offense, 'ruleId', 'unknown'));
         $message->setDescription($offense['message']);
         $message->setLine($offense['line']);
         $message->setChar($offense['column']);


### PR DESCRIPTION
It caused an error while sending a diff:

```
ERR-CONDUIT-CORE: Parameter 'name' has invalid type. Expected type 'string', got type 'bool'. at [<arcanist>/src/conduit/ConduitFuture.php:66]
```

It was cause by this line of code:

```
$message->setName($offense['ruleId'] || 'unknown');
```

that set the rule name to `true` instead of the ruleID