### PR TITLE
Fix black version parsing

### DIFF
--- a/src/BlackLinter.php
+++ b/src/BlackLinter.php
@@ -60,9 +60,8 @@ final class BlackLinter extends PythonExternalLinter {
       '%C --version', $this->getExecutableCommand());
 
     $matches = array();
-    if (preg_match('/version (?P<version>[^\s]+)$/', $stderr, $matches)) {
-      $this->version = $matches['version'];
-      return $this->version;
+    if (preg_match('/version (?P<version>[^\s]+)$/', $stdout, $matches)) {
+      return $matches['version'];
     } else {
       return false;
     }


### PR DESCRIPTION
Read the version string from STDOUT (not STDERR). Also, there's no need
to persist the parsed version string as an instance variable.