### PR TITLE
[BUGFIX] Fix undefined path variable

### DIFF
--- a/src/NodeExternalLinter.php
+++ b/src/NodeExternalLinter.php
@@ -102,7 +102,7 @@ abstract class NodeExternalLinter extends ArcanistExternalLinter {
       }
     }
 
-    if ($path) {
+    if (isset($path) && $path) {
       $binaryPath = $path.DIRECTORY_SEPARATOR.$bin;
       if (Filesystem::binaryExists($binaryPath)) {
         return $binaryPath;


### PR DESCRIPTION
If we didn't get a `$path` from `yarn`, it won't be set. Check for its existence to avoid
```Undefined variable: path```

This fixes the changes from a7cbfa1dc9b2daee679b2a9b05cd23dbdee81a6a