### PR TITLE
Specify a different npm package name from node binary

### DIFF
--- a/src/NodeExternalLinter.php
+++ b/src/NodeExternalLinter.php
@@ -68,6 +68,10 @@ abstract class NodeExternalLinter extends ArcanistExternalLinter {
     return parent::setLinterConfigurationValue($key, $value);
   }
 
+  public function getNpmPackageName() {
+    return $this->getNodeBinary();
+  }
+
   public function getInstallInstructions() {
     return pht(
       "\n\t%s[%s globally] run: `%s`\n\t[%s locally] run either: `%s` OR `%s`",
@@ -76,10 +80,10 @@ abstract class NodeExternalLinter extends ArcanistExternalLinter {
         '--cwd',
         'npm install --global yarn@1') : '',
       $this->getNodeBinary(),
-      'npm install --global '.$this->getNodeBinary(),
+      'npm install --global '.$this->getNpmPackageName(),
       $this->getNodeBinary(),
-      'npm install --save-dev '.$this->getNodeBinary(),
-      'yarn add --dev '.$this->getNodeBinary()
+      'npm install --save-dev '.$this->getNpmPackageName(),
+      'yarn add --dev '.$this->getNpmPackageName()
     );
   }
 

--- a/src/OpenApiLinter.php
+++ b/src/OpenApiLinter.php
@@ -82,6 +82,10 @@ final class OpenApiLinter extends NodeExternalLinter {
     return 'lint-openapi';
   }
 
+  public function getNpmPackageName() {
+    return 'ibm-openapi-validator';
+  }
+
   protected function getMandatoryFlags() {
     return array('--json');
   }


### PR DESCRIPTION
Not all npm packages use the same name for their main binary as the name of the package in the npm repository.

This change separates these configs so they can be different, but assumes they are the same as default behavior.

The result is that the OpenAPI linter now provides correct install instructions when it is missing:
```
Some linters failed:
    - ArcanistMissingLinterException: Unable to locate binary "lint-openapi" to run linter OpenApiLinter. You may need to install the binary, or adjust your linter configuration.
      TO INSTALL:
      [lint-openapi globally] run: `npm install --global ibm-openapi-validator`
      [lint-openapi locally] run either: `npm install --save-dev ibm-openapi-validator` OR `yarn add --dev ibm-openapi-validator`
```