### PR TITLE
Handle too much output from graphql-schema-linter, other json errors

### DIFF
--- a/src/GraphQLSchemaLinter.php
+++ b/src/GraphQLSchemaLinter.php
@@ -172,7 +172,14 @@ final class GraphQLSchemaLinter extends NodeExternalLinter {
         }
         */
 
+        if (strlen($stdout) == 65536) {
+          // We've exceeded the stdout buffer and this will not successfully json_decode()
+          throw new Exception(pht("%s returned too much output. Run the linter manually with:\n%s %s", $this->getLinterName(), $this->getExecutableCommand(), $this->getActivePath()));
+        }
         $json = json_decode($stdout, true);
+        if (json_last_error()) {
+          throw new JsonException(pht("\nUnable to decode result from %s: %s\n\nOutput was:\n%s", $this->getLinterName(), json_last_error_msg(), $stdout));
+        }
         $errors = $json['errors'];
 
         foreach ($errors as $error) {


### PR DESCRIPTION
When there are a lot of lint errors raised by `graphql-schema-linter`, the output JSON it produces can easily exceed the 2^16 character limit on the `$stdout` contents provided by Arcanist. The resulting truncated string will fail to JSON parse and the script will raise an error.

To correct for this, we check if there were any errors encountered in JSON decoding and raise these explicitly so the user can take action.

For this specific case, we see if the stdout buffer is at its maximum length and, if so, advise the author to run the linter outside of Arcanist and correct issues before running again.