### PR TITLE
Add `install-instructions` option to Node and Python linters

### DIFF
--- a/src/BlackLinter.php
+++ b/src/BlackLinter.php
@@ -67,10 +67,6 @@ final class BlackLinter extends PythonExternalLinter {
     }
   }
 
-  public function getInstallInstructions() {
-    return pht('pip3 install black');
-  }
-
   public function getLintSeverityMap() {
     return array(
       self::LINT_STYLE => ArcanistLintSeverity::SEVERITY_AUTOFIX,

--- a/src/DetectSecretsLinter.php
+++ b/src/DetectSecretsLinter.php
@@ -16,14 +16,14 @@
  */
 
 /**
- * Detect secrets in code base. 
+ * Detect secrets in code base.
  */
 final class DetectSecretsLinter extends PythonExternalLinter {
 
   private $message = "";
 
   public function getInfoName() {
-      return 'detect-secrets'; 
+      return 'detect-secrets';
   }
 
   public function getInfoURI() {
@@ -65,10 +65,6 @@ final class DetectSecretsLinter extends PythonExternalLinter {
 
   public function getPythonBinary() {
     return 'detect-secrets';
-  }
-
-  public function getInstallInstructions() {
-      return pht('pip3 install detect-secrets');
   }
 
   protected function getMandatoryFlags() {

--- a/src/Flake8Linter.php
+++ b/src/Flake8Linter.php
@@ -169,7 +169,7 @@ final class Flake8Linter extends PythonExternalLinter {
     if ($this->installInstructions) {
       return $this->installInstructions;
     }
-    return pht('Install flake8 using `%s`.', 'pip install flake8');
+    return parent::getInstallInstructions();
   }
 
   public function getUpgradeInstructions() {

--- a/src/NodeExternalLinter.php
+++ b/src/NodeExternalLinter.php
@@ -20,6 +20,7 @@
  */
 abstract class NodeExternalLinter extends ArcanistExternalLinter {
   private $cwd = '';
+  protected $customInstallInstructions = null;
 
   /**
    * Return the name of the external Node-based linter.
@@ -48,12 +49,19 @@ abstract class NodeExternalLinter extends ArcanistExternalLinter {
 
   public function getLinterConfigurationOptions() {
     $options = array(
+      'install-instructions' => array(
+        'type' => 'optional string',
+        'help' => pht(
+          'Specify custom instructions that should be used to install %s',
+          $this->getNodeBinary()
+        ),
+      ),
       $this->getLinterConfigurationName().'.cwd' => array(
         'type' => 'optional string',
         'help' => pht(
-            'Specify a project sub-directory for both the local %s install and the sub-directory to lint within.',
-            $this->getNodeBinary()
-          ),
+          'Specify a project sub-directory for both the local %s install and the sub-directory to lint within.',
+          $this->getNodeBinary()
+        ),
       ),
     );
     return $options + parent::getLinterConfigurationOptions();
@@ -61,6 +69,9 @@ abstract class NodeExternalLinter extends ArcanistExternalLinter {
 
   public function setLinterConfigurationValue($key, $value) {
     switch ($key) {
+      case 'install-instructions':
+        $this->customInstallInstructions = $value;
+        return;
       case $this->getLinterConfigurationName().'.cwd':
         $this->cwd = $value;
         return;
@@ -73,6 +84,13 @@ abstract class NodeExternalLinter extends ArcanistExternalLinter {
   }
 
   public function getInstallInstructions() {
+    if ($this->customInstallInstructions) {
+      return pht(
+        "\n\t[%s] run: `%s`",
+        $this->getNodeBinary(),
+        $this->customInstallInstructions,
+      );
+    }
     return pht(
       "\n\t%s[%s globally] run: `%s`\n\t[%s locally] run either: `%s` OR `%s`",
       $this->cwd ? pht("[%s globally] (required for %s) run: `%s`\n\t",

--- a/src/PinterestPylintLinter.php
+++ b/src/PinterestPylintLinter.php
@@ -48,10 +48,6 @@ class PinterestPylintLinter extends PythonExternalLinter {
     return 'pinterest-pylint';
   }
 
-  public function getInstallInstructions() {
-    return pht('Install pylint using `%s`.', 'pip install pylint');
-  }
-
   protected function getDefaultMessageSeverity($code) {
     switch (substr($code, 0, 1)) {
       case 'R':

--- a/src/PythonIsortLinter.php
+++ b/src/PythonIsortLinter.php
@@ -66,10 +66,6 @@ final class PythonIsortLinter extends PythonExternalLinter {
     }
   }
 
-  public function getInstallInstructions() {
-    return pht('Install isort using `pip3 install isort`.');
-  }
-
   protected function getMandatoryFlags() {
     $flags = array('--quiet', '--check-only', '--diff');
     if (version_compare($this->version, '4.3.18', '>=')) {


### PR DESCRIPTION
In some cases, a repository using Arcanist linters may have a particular way of installing lint dependencies — a `requirements.txt` or `package.json` file, say.

Here we add an `install-instructions` config option to all linters built on `PythonExternalLinter` or `NodeExternalLinter`. If specified, the text printed when the required binary cannot be found will be that specified in the configuration rather than the default text.

Child linters are modified to follow the convention set in the base classes so that they inherit this behavior. The `Flake8Linter` already had a mechanism for specifying custom instructions; this behavior is preserved for backwards compatibility.

For example, with `"install-instructions": "make lint_requirements"`, the message looks like:
```
Some linters failed:
    - ArcanistMissingLinterException: Unable to locate binary "lint-openapi" to run linter OpenApiLinter. You may need to install the binary, or adjust your linter configuration.
      TO INSTALL:
      lint-openapi run: `make lint_requirements`
```