### PR TITLE
Fix a XHPAST parse error

### DIFF
--- a/src/NodeExternalLinter.php
+++ b/src/NodeExternalLinter.php
@@ -88,7 +88,7 @@ abstract class NodeExternalLinter extends ArcanistExternalLinter {
       return pht(
         "\n\t[%s] run: `%s`",
         $this->getNodeBinary(),
-        $this->customInstallInstructions,
+        $this->customInstallInstructions
       );
     }
     return pht(


### PR DESCRIPTION
XHPAST can't handle a final trailing comma in the argument list.