### PR TITLE
Fixed an Arcanist crash bug caused by ruleId being null

### DIFF
--- a/src/ESLintLinter.php
+++ b/src/ESLintLinter.php
@@ -132,7 +132,7 @@ final class ESLintLinter extends NodeExternalLinter {
         $message = new ArcanistLintMessage();
         $message->setPath($file['filePath']);
         $message->setSeverity($this->mapSeverity($offense['severity']));
-        $message->setName(idx($offense, 'ruleId', 'unknown'));
+        $message->setName(nonempty(idx($offense, 'ruleId'), 'unknown'));
         $message->setDescription($offense['message']);
         $message->setLine($offense['line']);
         $message->setChar($offense['column']);


### PR DESCRIPTION
There is an edge case while running ESlint that can cause Arcanist to crash with the following error message:

> Linter "ESLintLinter" generated a lint message that is invalid because it does not have a name. Lint messages must have a name.

This edge case can be triggered by trying to lint a source file with a syntax error in it. That produces an ESlint JSON output where ruleId is null.

The idx function however does not fall back to using the provided default value 'unknown'.
It does actually the following: if the dictionary property value is null, and if the tested key (here ruleId) exists in the dictionary, then it returns null instead of the fallback default value.

This fix makes sure we never set a null value for the name property.

## Testing

- Ran `arc lint` in a local project with a modified JS source file that has a syntax error in it. Arcanist does not crash anymore with this fix