### PR TITLE
Handle missing "offense" values

### DIFF
--- a/src/ESLintLinter.php
+++ b/src/ESLintLinter.php
@@ -131,11 +131,11 @@ final class ESLintLinter extends NodeExternalLinter {
 
         $message = new ArcanistLintMessage();
         $message->setPath($file['filePath']);
-        $message->setSeverity($this->mapSeverity($offense['severity']));
+        $message->setSeverity($this->mapSeverity(idx($offense, 'severity', '0')));
         $message->setName(nonempty(idx($offense, 'ruleId'), 'unknown'));
-        $message->setDescription($offense['message']);
-        $message->setLine($offense['line']);
-        $message->setChar($offense['column']);
+        $message->setDescription(idx($offense, 'message'));
+        $message->setLine(idx($offense, 'line'));
+        $message->setChar(idx($offense, 'column'));
         $message->setCode($this->getLinterName());
         $messages[] = $message;
       }


### PR DESCRIPTION
We've encountered a number of cases where the eslint result doesn't
include values for all of these expected keys. Harden the code for these
cases using idx(). The internal Arcanist interface allows these values
to be `null`, which is idx()'s default value.

Fixes #62