### PR TITLE
Support multiple comma-separated 'extras'

### DIFF
--- a/src/PythonRequirementsLinter.php
+++ b/src/PythonRequirementsLinter.php
@@ -62,7 +62,7 @@ final class PythonRequirementsLinter extends ArcanistLinter {
 
   private function parseRequirement($line) {
     # PEP 508 (https://www.python.org/dev/peps/pep-0508/)
-    $regex = "/^(?P<name>[[:alnum:]][[:alnum:]\-_.]*(?:\[[[:alnum:]]+\])?)".
+    $regex = "/^(?P<name>[[:alnum:]][[:alnum:]\-_.]*(?:\[[[:alnum:],]+\])?)".
              "(?:\s*(?P<cmp>(~=|==|!=|<=|>=|<|>|===))\s*".
              "(?P<version>[[:alnum:]\-_.*+!]+))?".
              "(?:\s*;\s*(?P<environment>[^#]*))?/";


### PR DESCRIPTION
This regular expression previously only supported a single 'extra', but
multiple 'extras' can be specified when separated by commas.