### PR TITLE
Update OpenAPI Linter for supporting v0.36 and later

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,12 +182,12 @@ code constructs.
 
 Lint OpenAPI specifications using [openapi-validator](https://github.com/IBM/openapi-validator).
 
-_(Supports openapi-validator version 0.34.1 and later.)_
+_(Supports openapi-validator version 0.36.0 and later.)_
 
 ```json
 {
     "type": "openapi-spec",
-    "version": ">=0.34.1",
+    "version": ">=0.36.0",
     "openapi-spec.config": ".validaterc",
     "openapi-spec.debug": false,
     "openapi-spec.errors_only": true,

--- a/src/OpenApiLinter.php
+++ b/src/OpenApiLinter.php
@@ -121,28 +121,20 @@ final class OpenApiLinter extends NodeExternalLinter {
     /* Sample Output
     {
       "errors": {
-        "spectral": [
-          {
-            "path": [
-              "servers",
-              "0",
-              "url"
-            ],
-            "message": "Server URL should not have a trailing slash.",
-            "rule": "operation_id_naming_convention",
-            "line": 9
-          },
-        ]
+        "path": [
+          "servers",
+          "0",
+          "url"
+        ],
+        "message": "Server URL should not have a trailing slash.",
+        "rule": "operation_id_naming_convention",
+        "line": 9
       },
       "warnings": {
-        "spectral": [
-          {
-            "path": [],
-            "message": "OpenAPI object should have non-empty `tags` array.",
-            "rule": "operation_id_naming_convention",
-            "line": 0
-          }
-         ]
+        "path": [],
+        "message": "OpenAPI object should have non-empty `tags` array.",
+        "rule": "operation_id_naming_convention",
+        "line": 0
       },
       "error": true,
       "warning": true
@@ -163,19 +155,17 @@ final class OpenApiLinter extends NodeExternalLinter {
     return $messages;
   }
 
-  private function processOutput($path, $output_categories, $severity) {
+  private function processOutput($path, $output_category, $severity) {
     $messages = array();
-    foreach ($output_categories as $output_category) {
-      foreach ($output_category as $output) {
-        $message = new ArcanistLintMessage();
-        $message->setPath($path)
-          ->setCode(nonempty(idx($output, 'rule'), 'unknown'))
-          ->setName($this->getLinterName())
-          ->setLine($output['line'])
-          ->setDescription($output['message'])
-          ->setSeverity($severity);
-        $messages[] = $message;
-      }
+    foreach ($output_category as $output) {
+      $message = new ArcanistLintMessage();
+      $message->setPath($path)
+        ->setCode(nonempty(idx($output, 'rule'), 'unknown'))
+        ->setName($this->getLinterName())
+        ->setLine($output['line'])
+        ->setDescription($output['message'])
+        ->setSeverity($severity);
+      $messages[] = $message;
     }
     return $messages;
   }


### PR DESCRIPTION
- Output process functions is updated to support version v0.36 and later
- Updated Sample Output according to versions greater than v0.36