### PR TITLE
Fixed output message on OpenAPI linter.

### DIFF
--- a/src/OpenApiLinter.php
+++ b/src/OpenApiLinter.php
@@ -23,6 +23,7 @@ final class OpenApiLinter extends NodeExternalLinter {
   private $config = null;
   private $debug = false;
   private $errors_only = false;
+  private $linter_name = 'OPENAPI';
 
   public function getInfoName() {
     return 'OpenAPI Validator';
@@ -37,7 +38,11 @@ final class OpenApiLinter extends NodeExternalLinter {
   }
 
   public function getLinterName() {
-    return 'OPENAPI';
+    return $this->linter_name;
+  }
+
+  public function setLinterName($value) {
+    $this->linter_name = $value;
   }
 
   public function getLinterConfigurationName() {
@@ -154,11 +159,13 @@ final class OpenApiLinter extends NodeExternalLinter {
     $messages = array();
     foreach ($output_category as $output) {
       $message = new ArcanistLintMessage();
+      $data = $output[0];
+      $this->setLinterName(implode('/', $data['path']));
       $message->setPath($path)
-        ->setCode(nonempty(idx($output, 'rule'), 'unknown'))
+        ->setCode(nonempty(idx($data, 'rule'), 'unknown'))
         ->setName($this->getLinterName())
-        ->setLine($output['line'])
-        ->setDescription($output['message'])
+        ->setLine($data['line'])
+        ->setDescription($data['message'])
         ->setSeverity($severity);
       $messages[] = $message;
     }


### PR DESCRIPTION
Without the fix the out was like this:
```
>>> Lint for api/api_spec/.bundled_spec.yaml:

   Error  (unknown) OPENAPI
```

This is the fixed output:
```
>>> Lint for api/api_spec/.bundled_spec.yaml:

   Error  (builtin) components->schemas->EnhancedMatchStatusType->enum->4
    Null values are not allowed for any property.

            6878         - NOT_VALIDATED
            6879         - VALIDATING_IN_PROGRESS
            6880         - VALIDATION_COMPLETE
    >>>     6881         - null
                ^
            6882     EntityIdValues:
            6883       type: array
            6884       description: List of values for filtering
```