### PR TITLE
Pass working directory so ESLint can find plugins

### DIFF
--- a/src/ESLintLinter.php
+++ b/src/ESLintLinter.php
@@ -67,6 +67,10 @@ final class ESLintLinter extends NodeExternalLinter {
   }
 
   protected function getDefaultFlags() {
+    if ($this->cwd) {
+      $this->flags[] = '--resolve-plugins-relative-to';
+      $this->flags[] = $this->cwd;
+    }
     return $this->flags;
   }
 
@@ -84,10 +88,6 @@ final class ESLintLinter extends NodeExternalLinter {
         'type' => 'optional bool',
         'help' => pht('Specify whether eslint should autofix issues. (https://eslint.org/docs/user-guide/command-line-interface#fixing-problems)'),
       ),
-      'eslint.cwd' => array(
-        'type' => 'optional string',
-        'help' => pht('Directory eslint should resolve plugins relative to. (https://eslint.org/docs/user-guide/command-line-interface#--resolve-plugins-relative-to)'),
-      ),
     );
     return $options + parent::getLinterConfigurationOptions();
   }
@@ -99,17 +99,13 @@ final class ESLintLinter extends NodeExternalLinter {
         $this->flags[] = $value;
         return;
       case 'eslint.env':
-        $this->flags[] = '--env ';
+        $this->flags[] = '--env';
         $this->flags[] = $value;
         return;
       case 'eslint.fix':
         if ($value) {
-          $this->flags[] = '--fix ';
+          $this->flags[] = '--fix';
         }
-        return;
-      case 'eslint.cwd':
-        $this->flags[] = '--resolve-plugins-relative-to ';
-        $this->flags[] = $value;
         return;
     }
     return parent::setLinterConfigurationValue($key, $value);

--- a/src/ESLintLinter.php
+++ b/src/ESLintLinter.php
@@ -84,6 +84,10 @@ final class ESLintLinter extends NodeExternalLinter {
         'type' => 'optional bool',
         'help' => pht('Specify whether eslint should autofix issues. (https://eslint.org/docs/user-guide/command-line-interface#fixing-problems)'),
       ),
+      'eslint.cwd' => array(
+        'type' => 'optional string',
+        'help' => pht('Directory eslint should resolve plugins relative to. (https://eslint.org/docs/user-guide/command-line-interface#--resolve-plugins-relative-to)'),
+      ),
     );
     return $options + parent::getLinterConfigurationOptions();
   }
@@ -102,6 +106,10 @@ final class ESLintLinter extends NodeExternalLinter {
         if ($value) {
           $this->flags[] = '--fix ';
         }
+        return;
+      case 'eslint.cwd':
+        $this->flags[] = '--resolve-plugins-relative-to ';
+        $this->flags[] = $value;
         return;
     }
     return parent::setLinterConfigurationValue($key, $value);

--- a/src/NodeExternalLinter.php
+++ b/src/NodeExternalLinter.php
@@ -19,7 +19,7 @@
  * Base class for external Node-based linters.
  */
 abstract class NodeExternalLinter extends PinterestExternalLinter {
-  private $cwd = '';
+  protected $cwd = '';
 
   /**
    * Return the name of the external Node-based linter.


### PR DESCRIPTION
Directory structure:
```
/Users/mmark/code/my-repo
|-- .arclint
|-- client
    |-- node_modules
    |-- .eslintrc
|-- server
    |-- node_modules
    |-- .eslintrc
```

Before the change:
```
$ './client/node_modules/.bin/eslint' '--format=json' '--no-color' '--config' './client/.eslintrc' '--fix ' '/Users/mmark/code/my-repo/client/src/index.js'

Oops! Something went wrong! :(

ESLint: 6.8.0.

ESLint couldn't find the plugin "eslint-plugin-react".

(The package "eslint-plugin-react" was not found when loaded as a Node module from the directory "/Users/mmark/code/my-repo".)
```

After the change:
```
$ './client/node_modules/.bin/eslint' '--format=json' '--no-color' '--config' './client/.eslintrc' '--fix ' '/Users/mmark/code/metro/client/src/index.js' '--resolve-plugins-relative-to' './client'

[successful output]
```

Using `.arclint` entry:
```
    "client-eslint": {
      "type": "eslint",
      "include": "(client/.*\\.js$)",
      "bin": "./client/node_modules/.bin/eslint",
      "eslint.config": "./client/.eslintrc",
      "eslint.fix": true,
      "eslint.cwd": "./client"
    }
```