### PR TITLE
Add multibyte (unicode) safety and key check fix

### DIFF
--- a/src/ESLintLinter.php
+++ b/src/ESLintLinter.php
@@ -165,8 +165,8 @@ final class ESLintLinter extends NodeExternalLinter {
         $message->setChar(idx($offense, 'column'));
         $message->setCode($this->getLinterName());
 
-        $fix = $offense['fix'];
-        if ($this->parseFixes && $fix) {
+        if ($this->parseFixes && isset($offense['fix'])) {
+          $fix = $offense['fix'];
           // If there's a fix available, suggest it to the user.
           // We don't want to rely on the --fix flag for eslint because it will
           // silently fix, and then arc won't know it should patch new changes
@@ -177,7 +177,8 @@ final class ESLintLinter extends NodeExternalLinter {
           $rangeLength = $rangeEnd-$rangeStart;
           $originalText = $this->getData($path);
 
-          $originalSlice = substr($originalText, $rangeStart, $rangeLength);
+          // Make sure to always use multibyte safe string ranges.
+          $originalSlice = mb_substr($originalText, $rangeStart, $rangeLength);
           $message->setOriginalText($originalSlice);
 
           $replacementSlice = $fix['text'];


### PR DESCRIPTION
1) Update substrings to be resolved using `mb_substr` instead of `substr` in case the input text is unicode.

2) Add `isset` check before resolving `'fix'` index in the offense. This is throwing an error on every linter without a fix.

Tested by making local changes with unicode strings and verifying the fix was applied as expected:

#Before fix
```
[2021-06-23 05:56:35] ERROR 8: Undefined index: fix at [[repo]/.pinterest-linters/src/ESLintLinter.php:168]
arcanist(), phutil(), pinterest-linters(head=[branch], ref.master=029aa63c3ef7, ref.[branch]=9c6778333e2a)
  #0 ESLintLinter::parseLinterOutput(string, integer, string, string) called at [<arcanist>/src/lint/linter/ArcanistExternalLinter.php:437]
  #1 ArcanistExternalLinter::resolveFuture(string, ExecFuture) called at [<arcanist>/src/lint/linter/ArcanistFutureLinter.php:34]
  #2 ArcanistFutureLinter::didLintPaths(array) called at [<arcanist>/src/lint/engine/ArcanistLintEngine.php:605]
  #3 ArcanistLintEngine::executeDidLintOnPaths(ESLintLinter, array) called at [<arcanist>/src/lint/engine/ArcanistLintEngine.php:556]
  #4 ArcanistLintEngine::executeLintersOnChunk(array, array) called at [<arcanist>/src/lint/engine/ArcanistLintEngine.php:484]
  #5 ArcanistLintEngine::executeLinters(array) called at [<arcanist>/src/lint/engine/ArcanistLintEngine.php:216]
  #6 ArcanistLintEngine::run() called at [<arcanist>/src/workflow/ArcanistLintWorkflow.php:337]
  #7 ArcanistLintWorkflow::run() called at [<arcanist>/scripts/arcanist.php:394]
>>> Lint for [file].js
   Error  (ESLINT) no-unused-vars
    'hahaha' is assigned a value but never used.

              77     ;
              78 
              79 
    >>>       80   const hahaha = "✂️✂️✂️✂️✂️✂️,✂️✂️✂️✂️✂️✂️,✂️✂️✂️✂️".split     (
                         ^
              81     ","
              82   );
              83 

   Auto-Fix  (ESLINT) prettier/prettier
    Replace `"✂️✂️✂️✂️✂️✂️,✂️✂️✂️✂️✂️✂️,✂️✂️✂️✂️".split·····(⏎····","⏎··`
    with `'✂️✂️✂️✂️✂️✂️,✂️✂️✂️✂️✂️✂️,✂️✂️✂️✂️'.split(','`

              77     ;
              78 
              79 
    >>> -     80   const hahaha = "✂️✂️✂️✂️✂️✂️,✂️✂️✂️✂️✂️✂️,✂️✂️✂️✂️".split     (
        +          const hahaha = '✂️✂️✂️✂️✂️✂️,✂️✂️✂️✂️✂️✂️,✂️✂️✂️✂️'.split(',Ắ✂️✂️,✂️✂️✂️✂️".split     (
              81     ","
              82   );
              83 
              84   const loadImage = useCallback(async () => {

```

After fix:
```
>>> Lint for [file].js
   Error  (ESLINT) no-unused-vars
    'hahaha' is assigned a value but never used.

              77     ;
              78 
              79 
    >>>       80   const hahaha = "✂️✂️✂️✂️✂️✂️,✂️✂️✂️✂️✂️✂️,✂️✂️✂️✂️".split     (
                         ^
              81     ","
              82   );
              83 

   Auto-Fix  (ESLINT) prettier/prettier
    Replace `"✂️✂️✂️✂️✂️✂️,✂️✂️✂️✂️✂️✂️,✂️✂️✂️✂️".split·····(⏎····","⏎··`
    with `'✂️✂️✂️✂️✂️✂️,✂️✂️✂️✂️✂️✂️,✂️✂️✂️✂️'.split(','`

              77     ;
              78 
              79 
    >>> -     80   const hahaha = "✂️✂️✂️✂️✂️✂️,✂️✂️✂️✂️✂️✂️,✂️✂️✂️✂️".split     (
        -     81     ","
        -     82   );
        +          const hahaha = '✂️✂️✂️✂️✂️✂️,✂️✂️✂️✂️✂️✂️,✂️✂️✂️✂️'.split(',');
              83 

```