### PR TITLE
Revise the thriftcheck error pattern

### DIFF
--- a/src/ThriftCheckLinter.php
+++ b/src/ThriftCheckLinter.php
@@ -104,9 +104,9 @@ final class ThriftCheckLinter extends PinterestExternalLinter {
   protected function parseLinterOutput($path, $err, $stdout, $stderr) {
     $lines = phutil_split_lines($stdout, false);
 
-    // file.thrift:3:1:error: unable to find include path for "bar.thrift" (include.path)
+    // file.thrift:3:1: error: unable to find include path for "bar.thrift" (include.path)
     $regexp =
-      '/^(?:.*?):(?P<line>\d+):(?P<char>\d+):(?P<severity>(error|warning)): '.
+      '/^(?:.*?):(?P<line>\d+):(?P<char>\d+): ?(?P<severity>(error|warning)): '.
       '(?P<msg>.*) \((?P<code>.*)\)$/';
 
     $messages = array();


### PR DESCRIPTION
More recent versions of thriftcheck use a more compliant GCC-style
output format which includes a space before the "severity" group.
This matches similar tools, like shellcheck.

https://github.com/pinterest/thriftcheck/pull/32

This change adjusts the handler's pattern to parse this format in a
backwards-compatible way (even though backwards compatibility isn't
critical long-term as thriftcheck itself is close to its 1.0 release).