### PR TITLE
Support more variants of Black's version string

### DIFF
--- a/src/BlackLinter.php
+++ b/src/BlackLinter.php
@@ -60,7 +60,7 @@ final class BlackLinter extends PythonExternalLinter {
       '%C --version', $this->getExecutableCommand());
 
     $matches = array();
-    if (preg_match('/version (?P<version>[^\s]+)$/', $stdout, $matches)) {
+    if (preg_match('/(?P<version>\d+\.\d+[^\s]*)/', $stdout, $matches)) {
       return $matches['version'];
     } else {
       return false;


### PR DESCRIPTION
Black current reports its version string like:

    black, 22.1.0 (compiled: yes)

... but it previously reported version strings like:

    black, version 21.5b2

Use a more flexible regular expression that matches both.