### PR TITLE
Look for packages below the `cwd` path

### DIFF
--- a/src/GraphQLSchemaLinter.php
+++ b/src/GraphQLSchemaLinter.php
@@ -77,21 +77,11 @@ final class GraphQLSchemaLinter extends NodeExternalLinter {
     }
 
     if (!empty($this->dependencyVersions)) {
-      $bin_path = Filesystem::resolveBinary($this->getDefaultBinary());
-      $bin_root = dirname($bin_path);
-
-      if (empty($bin_root)) {
-        $message = pht(
-          "%s cannot resolve '%s' in the current \$PATH",
-          get_class($this),
-          $this->getDefaultBinary(),
-        );
-        throw new ArcanistMissingLinterException($message);
-      }
+      $package_root = Filesystem::resolvePath($this->cwd, $this->getProjectRoot());
 
       foreach ($this->dependencyVersions as $name => $required) {
         list($err, $stdout, $stderr) = newv('ExecFuture', array('npm list -s --depth=0 --json'))
-          ->setCWD($bin_root)
+          ->setCWD($package_root)
           ->resolve();
         $json = json_decode($stdout, true);
         $dep_version = !empty($json) ? idxv($json, array('dependencies', $name, 'version')) : null;

--- a/src/GraphQLSchemaLinter.php
+++ b/src/GraphQLSchemaLinter.php
@@ -77,9 +77,19 @@ final class GraphQLSchemaLinter extends NodeExternalLinter {
     }
 
     if (!empty($this->dependencyVersions)) {
+      $bin_path = Filesystem::resolveBinary($this->getDefaultBinary());
+      $bin_root = dirname($bin_path);
+
+      if (empty($bin_root)) {
+        $message = pht(
+          "%s cannot resolve '%s' in the current \$PATH",
+          get_class($this),
+          $this->getDefaultBinary(),
+        );
+        throw new ArcanistMissingLinterException($message);
+      }
 
       foreach ($this->dependencyVersions as $name => $required) {
-        $bin_root = dirname($this->getDefaultBinary());
         list($err, $stdout, $stderr) = newv('ExecFuture', array('npm list -s --depth=0 --json'))
           ->setCWD($bin_root)
           ->resolve();


### PR DESCRIPTION
We were previously using the binary path to determine the location
of installed packages (dependencies), but that's unreliable because
it can vary based on installation method, the $PATH, etc.

Instead, we trust our configured `cwd` to determine the package
installation root.