### PR TITLE
Handle text-wrapped output from `flake8 --version`

### DIFF
--- a/src/Flake8Linter.php
+++ b/src/Flake8Linter.php
@@ -118,7 +118,7 @@ final class Flake8Linter extends PythonExternalLinter {
     $regex =
       '/^(?P<version>\d+\.\d+(?:\.\d+)?) '. # flake8 version
       '\((?P<extensions>.*)\) '.            # extension list
-      '.*(?P<python>\d+\.\d+\.\d+)/';       # python version
+      '.*(?P<python>\d+\.\d+\.\d+)/s';      # python version
     $matches = array();
     if (!preg_match($regex, $stdout, $matches)) {
       return false;


### PR DESCRIPTION
`flake8` uses the `argparse` library, which by default [wraps output to a max character limit](https://docs.python.org/dev/library/argparse.html#formatter-class).

When running `flake8 --version` in an environment with several `flake8` plugins, the resulting output can easily be split over multiple lines, e.g.
```
4.0.1 (assertive: 2.1.0, dlint: 0.12.0, mccabe: 0.6.1, naming: 0.11.1,
pinboard-author: 1.0.0, pinboard-except-comma: 1.0.0, pinboard-exception-
message: 1.0.0, pinboard-imports: 1.0.0, pinboard-log-lint-errors: 1.0.0,
pinboard-lru-cache: 1.0.0, pinboard-mutable-args: 1.0.0, pinboard-python3:
1.1.0, pinboard-super-call: 1.0.0, pinboard-testcase: 1.0.0, pinboard-tuples:
1.0.0, pinboard-unittests: 1.0.0, pycodestyle: 2.8.0, pyflakes: 2.4.0) CPython
3.7.13 on Darwin
```

Our regex used to determine the `flake8` and `python` versions from this output uses a `.` to match all characters between these two version strings; however by default `.` will not match the newlines that are in the wrapped `flake8` output. We fix this by appending the [`PCRE_DOTALL`](https://www.php.net/manual/en/reference.pcre.pattern.modifiers.php) modifier, which allows `.` to match newlines and fixes the version parsing.