### PR TITLE
Check additional linter dependencies only if run

### DIFF
--- a/src/GraphQLSchemaLinter.php
+++ b/src/GraphQLSchemaLinter.php
@@ -76,6 +76,10 @@ final class GraphQLSchemaLinter extends NodeExternalLinter {
       $version = $matches[1];
     }
 
+    return $version;
+  }
+
+  protected function checkAdditionalVersions() {
     if (!empty($this->dependencyVersions)) {
       $package_root = Filesystem::resolvePath($this->cwd, $this->getProjectRoot());
 
@@ -86,7 +90,7 @@ final class GraphQLSchemaLinter extends NodeExternalLinter {
         $json = json_decode($stdout, true);
         $dep_version = !empty($json) ? idxv($json, array('dependencies', $name, 'version')) : null;
 
-        if (empty($version) || !$this->checkVersion($dep_version, $required)) {
+        if (empty($dep_version) || !$this->checkVersion($dep_version, $required)) {
           $message = pht(
             "%s requires graphql-schema-linter '%s' dependency version %s.",
             get_class($this),
@@ -106,8 +110,6 @@ final class GraphQLSchemaLinter extends NodeExternalLinter {
         }
       }
     }
-
-    return $version;
   }
 
   public function getLinterConfigurationOptions() {

--- a/src/PinterestExternalLinter.php
+++ b/src/PinterestExternalLinter.php
@@ -21,6 +21,22 @@
 abstract class PinterestExternalLinter extends ArcanistExternalLinter {
   private $customInstallInstructions = null;
 
+  public function willLintPaths(array $paths) {
+    $this->checkAdditionalVersions();
+    return parent::willLintPaths($paths);
+  }
+
+  /**
+   * Check additional version requirements for the linter
+   * Unlike checkBinaryVersion(), which is run on load,
+   *   these checks only run if the linter matches any paths.
+   * Use this to prevent imposing a linter's requirements on an
+   *   entire repo when only a subset of developers use it.
+   */
+  protected function checkAdditionalVersions() {
+    return;
+  }
+
   public function getInstallInstructions() {
     if ($this->customInstallInstructions) {
       return pht('Install %s using `%s`.', $this->getBinary(), $this->customInstallInstructions);


### PR DESCRIPTION
A couple of our linters, `Flake8` and `GraphQLSchema`, have additional version checks for the linter's dependencies. These are currently executed when checking the version of the linter binary.

This commit defers checking of these additional dependencies until the time where the linter is to actually be run, via a new `checkAdditionalVersions()` method.

In a larger codebase, it may be common to have many linters configured that only operate on a subset of it (different languages, subdirectories in a monorepo, etc). `arcanist` currently accounts for this in part by allowing a linter not to be installed, and only complaining about that if it finds paths that require that linter. In a similar manner, this commit takes the approach that if a developer has a linter installed for one part of the codebase, she should not be forced to install all the dependencies required by that linter in another part of the codebase she'll never use.